### PR TITLE
Advana model support & prompt template improvements.

### DIFF
--- a/backend/.envs/.local/.django
+++ b/backend/.envs/.local/.django
@@ -13,4 +13,4 @@ REDIS_URL=redis://redis:6379/0
 CELERY_FLOWER_USER=debug
 CELERY_FLOWER_PASSWORD=debug
 
-ES_URL=https://06b2-72-253-135-20.ngrok-free.app
+ES_URL=https://ad7a-72-253-135-20.ngrok-free.app

--- a/backend/apps/prompt/api/views.py
+++ b/backend/apps/prompt/api/views.py
@@ -2,7 +2,7 @@ from rest_framework import status as HTTP_STATUS
 from rest_framework.decorators import api_view
 from rest_framework.request import Request
 from rest_framework.response import Response
-from apps.prompt.services.chat import ChatAgentService, get_bedrock_model
+from apps.prompt.services.chat import ChatAgentService
 from bravo11.services.es import (
     GeoPoint, 
     get_es_client, 
@@ -11,45 +11,74 @@ from bravo11.services.es import (
     get_assets_by_id,
     transform_asset_details_resp
 )
+from apps.prompt.services.bedrock_client import get_bedrock_model, BedrockModel
 from apps.prompt.services.prompts import contruct_context
+from apps.prompt.services.avana_client import AvanaLangchainLlm, AvanaModel
 
+
+MODEL_CLASS_MAP = {
+    AvanaModel.llama_2_13b_chat_gptq: AvanaLangchainLlm(model=AvanaModel.llama_2_13b_chat_gptq),
+    AvanaModel.mistral_78_instruct_v2_awq: AvanaLangchainLlm(model=AvanaModel.mistral_78_instruct_v2_awq),
+    BedrockModel.llama2_70b_chat_v1: get_bedrock_model(model=BedrockModel.llama2_70b_chat_v1),
+    BedrockModel.llama2_13b_chat_v1: get_bedrock_model(model=BedrockModel.llama2_13b_chat_v1),
+}
 
 @api_view(["POST"])
 def prompt(req: Request):
-    # Services
-    model = get_bedrock_model()
-    es_client = get_es_client()
-    chat_agent = ChatAgentService(model)
 
     # Data
     prompt = req.data.get("prompt", "")
     messages = req.data.get("messages", [])
     bounding_box = req.data.get("bounding_box", None)
     asset_id = req.data.get("asset_id", None)
+    model = MODEL_CLASS_MAP[req.data.get("model", BedrockModel.llama2_70b_chat_v1)]
     bounding_box_resp = {}
     asset_ids_resp = {}
 
+    # Services
+    es_client = get_es_client()
+    chat_agent = ChatAgentService(model)
+
+    
     # If has bounding box get context from ES
     if bounding_box:
-        bounding_box_resp = get_asset_data_from_geo_point(
-            es_client,
-            GeoPoint(lat=bounding_box["top_left"]["lat"], lon=bounding_box["top_left"]["lon"]),
-            GeoPoint(lat=bounding_box["bottom_right"]["lat"], lon=bounding_box["bottom_right"]["lon"])
-        )
+        try:
+            bounding_box_resp = get_asset_data_from_geo_point(
+                es_client,
+                GeoPoint(lat=bounding_box["top_right"]["lat"], lon=bounding_box["top_right"]["lon"]),
+                GeoPoint(lat=bounding_box["bottom_left"]["lat"], lon=bounding_box["bottom_left"]["lon"])
+            )
+        except Exception as e:
+            return Response(
+                {"message": f"Error getting bounding box data from ES: {str(e)}"}, 
+                status=HTTP_STATUS.HTTP_400_BAD_REQUEST
+            )
 
     if asset_id:
-        asset_ids_resp = get_assets_by_id(
-            es_client, 
-            asset_id
-        )
+        try:
+            asset_ids_resp = get_assets_by_id(
+                es_client, 
+                asset_id
+            )
+        except Exception as e:
+            return Response(
+                {"message": f"Error getting asset data from ES: {str(e)}"}, 
+                status=HTTP_STATUS.HTTP_400_BAD_REQUEST
+            )
         
-
-    output = chat_agent.invoke(
-        prompt, 
-        messages=messages, 
-        context=contruct_context(
-            bounding_entity_data=transform_asset_resp(bounding_box_resp), 
-            entity_detail=transform_asset_details_resp(asset_ids_resp), 
+    try:
+        output = chat_agent.invoke(
+            prompt, 
+            messages=messages, 
+            context=contruct_context(
+                bounding_entity_data=transform_asset_resp(bounding_box_resp), 
+                entity_detail=transform_asset_details_resp(asset_ids_resp), 
+            )
         )
-    )
+    except Exception as e:
+        return Response(
+                {"message": f"Error generating LLM response: {str(e)}"}, 
+                status=HTTP_STATUS.HTTP_400_BAD_REQUEST
+            )
     return Response({"message": output}, status=HTTP_STATUS.HTTP_200_OK)
+    

--- a/backend/apps/prompt/services/avana_client.py
+++ b/backend/apps/prompt/services/avana_client.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+from openai import OpenAI as AvanaLlmInterface
+from django.conf import settings
+
+import logging
+from typing import (
+
+    Any,
+    Dict,
+    List,
+    Tuple,
+    Union,
+    Optional,
+)
+
+from langchain_core.language_models.llms import BaseLLM
+from langchain_core.pydantic_v1 import Field, root_validator
+from langchain_core.utils import get_pydantic_field_names
+from langchain_core.utils.utils import build_extra_kwargs
+from langchain_community.llms.openai import update_token_usage
+
+from langchain_core.callbacks import (
+    CallbackManagerForLLMRun,
+)
+from langchain_core.outputs import LLMResult
+from langchain_core.pydantic_v1 import Field, root_validator
+from langchain_core.utils import get_pydantic_field_names
+from langchain_core.utils.utils import build_extra_kwargs
+
+
+logger = logging.getLogger(__name__)
+
+class AvanaModel:
+    llama_2_13b_chat_gptq = "Llama-2-13b-chat-GPTQ"
+    mistral_78_instruct_v2_awq = "mistral-78-Instruct-v0.2-AWQ"
+
+def avana_llm_client(model=AvanaModel.llama_2_13b_chat_gptq):
+    '''
+        completion = client.completions.create(model="Llama-2-13b-chat-GPTQ", prompt="San Francisco is ")
+        print("Completion result:", completion)
+    '''
+    return AvanaLlmInterface(
+        api_key="EMPTY",
+        base_url=settings.STITCHES_API_URL,
+    )
+
+
+# Langchain llm service
+class AvanaLangchainLlm(BaseLLM):
+    """Base Avana large language model class."""
+
+    @property
+    def _llm_type(self) -> str:
+        """Return type of llm."""
+        return "avana"
+
+    @classmethod
+    def get_lc_namespace(cls) -> List[str]:
+        """Get the namespace of the langchain object."""
+        return ["langchain", "llms", "avana"]
+
+    @property
+    def lc_attributes(self) -> Dict[str, Any]:
+        attributes: Dict[str, Any] = {}
+        return attributes
+
+    @classmethod
+    def is_lc_serializable(cls) -> bool:
+        return True
+
+    client: Any = Field(default=None, exclude=True)  #: :meta private:
+    model_name: str = Field(default=AvanaModel.llama_2_13b_chat_gptq, alias="model")
+    
+    """Batch size to use when passing multiple documents to generate."""
+    request_timeout: Union[float, Tuple[float, float], Any, None] = Field(
+        default=None, alias="timeout"
+    )
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        allow_population_by_field_name = True
+
+    @root_validator(pre=True)
+    def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Build extra kwargs from additional params that were passed in."""
+        all_required_field_names = get_pydantic_field_names(cls)
+        extra = values.get("model_kwargs", {})
+        values["model_kwargs"] = build_extra_kwargs(
+            extra, values, all_required_field_names
+        )
+        return values
+
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
+        values["client"] = avana_llm_client().completions
+        return values
+    
+    def _generate(
+        self,
+        prompts: List[str],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> LLMResult:
+        """Call out to OpenAI's endpoint with k unique prompts.
+
+        Args:
+            prompts: The prompts to pass into the model.
+            stop: Optional list of stop words to use when generating.
+
+        Returns:
+            The full LLM output.
+
+        Example:
+            .. code-block:: python
+
+                response = openai.generate(["Tell me a joke."])
+        """
+        params = self._invocation_params
+        params = {**params, **kwargs}
+        sub_prompts = self.get_sub_prompts(params, prompts, stop)
+        choices = []
+        token_usage: Dict[str, int] = {}
+        # Get the token usage from the response.
+        # Includes prompt, completion, and total tokens used.
+        _keys = {"completion_tokens", "prompt_tokens", "total_tokens"}
+        system_fingerprint: Optional[str] = None
+        for _prompts in sub_prompts:
+            
+            response = self.client.create(
+                self, prompt=_prompts, run_manager=run_manager, **params
+            )
+            if not isinstance(response, dict):
+                # V1 client returns the response in an PyDantic object instead of
+                # dict. For the transition period, we deep convert it to dict.
+                response = response.dict()
+
+            choices.extend(response["choices"])
+            update_token_usage(_keys, response, token_usage)
+            if not system_fingerprint:
+                system_fingerprint = response.get("system_fingerprint")
+        return self.create_llm_result(
+            choices,
+            prompts,
+            params,
+            token_usage,
+            system_fingerprint=system_fingerprint,
+        )

--- a/backend/apps/prompt/services/bedrock_client.py
+++ b/backend/apps/prompt/services/bedrock_client.py
@@ -1,0 +1,21 @@
+
+
+from langchain_community.llms.bedrock import Bedrock
+from apps.prompt.services.boto_client import get_bedrock_client
+
+class BedrockModel:
+    llama2_70b_chat_v1 = "meta.llama2-70b-chat-v1"
+    llama2_13b_chat_v1 = "meta.llama2-13b-chat-v1"
+
+def get_bedrock_model(model: str = 'meta.llama2-70b-chat-v1') -> Bedrock:
+    inference_modifier = {
+        "temperature": 0.3,
+        "top_p": 0.9,
+        "max_gen_len": 2048,
+    }
+    return Bedrock(
+        client=get_bedrock_client(),
+        model_id=model,
+        region_name="us-east-1",
+        model_kwargs=inference_modifier
+    )

--- a/backend/apps/prompt/services/chat.py
+++ b/backend/apps/prompt/services/chat.py
@@ -1,7 +1,7 @@
-from typing import Any, Sequence
+from typing import Any, Sequence, Type
 from langchain.agents import initialize_agent, AgentType, AgentExecutor
 from langchain.memory import ChatMessageHistory
-from langchain_community.llms.bedrock import Bedrock
+from langchain_core.language_models.llms import LLM
 from apps.prompt.services.tools import ship_details
 from apps.prompt.services.prompts import template, template_map
 from langchain.agents import AgentExecutor
@@ -126,22 +126,9 @@ class MessageType:
     user = "user"
     agent = "agent"
 
-def get_bedrock_model(model: str = 'meta.llama2-70b-chat-v1') -> Bedrock:
-    inference_modifier = {
-        "temperature": 0.3,
-        "top_p": 0.9,
-        "max_gen_len": 2048,
-    }
-    return Bedrock(
-        client=get_bedrock_client(),
-        model_id=model,
-        region_name="us-east-1",
-        model_kwargs=inference_modifier
-    )
-
 
 class ChatAgentService:
-    def __init__(self, model: Bedrock) -> None:
+    def __init__(self, model: Type[LLM]) -> None:
         self.model = model
 
         # Setup agent
@@ -182,7 +169,7 @@ class ChatAgentService:
 
         return demo_ephemeral_chat_history
         
-    #TODO: temporary uncomment to disable agent tools
+    # TODO: temporary uncomment to disable agent tools
     # def invoke(self, prompt: str, messages: list[object] = []) -> Any:
     #     chat_message = self._create_messages(messages)
     #     agent_resp = self.agent.invoke({

--- a/backend/apps/prompt/services/prompts.py
+++ b/backend/apps/prompt/services/prompts.py
@@ -23,7 +23,7 @@ Thought:{agent_scratchpad}'''
 
 
 template_map = '''
-Answer the following question based on the below context data.
+Answer the following question based on the below context data. If there is no context data, answer the question with "I am unsure, No data found.".
 
 Question: {input}
 

--- a/backend/bravo11/services/es.py
+++ b/backend/bravo11/services/es.py
@@ -32,8 +32,8 @@ def transform_asset_resp(json_data: dict):
 
 def get_asset_data_from_geo_point(
         es_client: Elasticsearch,
-        top_left: GeoPoint, 
-        bottom_right: GeoPoint, 
+        top_right: GeoPoint, 
+        bottom_left: GeoPoint, 
         asset_type: str = "AssetTypeSatellite",
         max_results: int = 10):
     
@@ -46,14 +46,14 @@ def get_asset_data_from_geo_point(
             "filter": {
                 "geo_bounding_box": {
                 "location": {
-                    "top_left": {
-                        "lat": top_left.lat,
-                        "lon": top_left.lon
+                    "top_right": {
+                        "lat": top_right.lat,
+                        "lon": top_right.lon
                     
                     },
-                    "bottom_right": {
-                        "lat": bottom_right.lat,
-                        "lon": bottom_right.lon
+                    "bottom_left": {
+                        "lat": bottom_left.lat,
+                        "lon": bottom_left.lon
                     }
                 }
                 }

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -344,3 +344,4 @@ AWS_ACCESS_KEY = env("AWS_ACCESS_KEY")
 AWS_SECRET_KEY = env("AWS_SECRET_KEY")
 
 ES_URL = env("ES_URL", default="http://localhost:9200")
+STITCHES_API_URL = env("STITCHES_API_URL", default="http://llms.stitches.mil/v1")

--- a/backend/config/settings/local.py
+++ b/backend/config/settings/local.py
@@ -11,7 +11,7 @@ SECRET_KEY = env(
     default="atHRUg7pQCh0qpZsnYaLfnKBUH43H3w7h2mbtPqdirWGijPBwjb0IMjLkXbTX7mD",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]
+ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", ".ngrok-free.app"]
 
 # CACHES
 # ------------------------------------------------------------------------------
@@ -58,3 +58,7 @@ INSTALLED_APPS += ["django_extensions"]  # noqa: F405
 CELERY_TASK_EAGER_PROPAGATES = True
 # Your stuff...
 # ------------------------------------------------------------------------------
+
+
+# disable cors
+CORS_ALLOW_ALL_ORIGINS = True

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -35,3 +35,4 @@ langgraph==0.0.23
 
 #es
 elasticsearch_dsl==8.12.0
+openai==1.11.1


### PR DESCRIPTION
- Adds property `model` to the `/prompt` api. Allows value's `meta.llama2-70b-chat-v1` (Bedrock), `meta.llama2-13b-chat-v1` (Bedrock), `Llama-2-13b-chat-GPTQ` (Advana hosted), `mistral-78-Instruct-v0.2-AWQ` (Advana hosted). If no value is selected default value is  `meta.llama2-70b-chat-v1`.
```
POST /prompt
{
    "model": "meta.llama2-70b-chat-v1",
    ....
 }
```
- Improve prompt templating